### PR TITLE
(SIMP-6536) pup_5 missing in gitlab-ci.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,13 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
+.pup_5: &pup_5
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
 .pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4.5'
   variables:


### PR DESCRIPTION
SIMP-6436 #comment Fix pupmod-simp-simp_bolt GitLab config