### PR TITLE
(SIMP-7108) Set up SIMP Env on Bolt controller

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Oct 16 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 0.2.0
+* Wed Oct 16 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 0.2.0
 - Configured Bolt to request a pseudo TTY for SSH sessions if specified.
 - Configured new logs to be appended to the log file instead of overwriting.
 - Updated spec tests.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Sep 23 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 0.2.0
+- Configured Bolt to utilize a SIMP Omni-Environment.
+- Configured Bolt to request a pseudo TTY for SSH sessions if specified.
+- Configured new logs to be appended to the log file instead of overwriting.
+- Updated spec tests.
+- Updated README.md and REFERENCE.md.
+
 * Tue Jul 02 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
 - Updated README.md
 - Added REFERENCE.md

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,4 @@
-* Mon Sep 23 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 0.2.0
-- Configured Bolt to utilize a SIMP Omni-Environment.
+* Mon Oct 16 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 0.2.0
 - Configured Bolt to request a pseudo TTY for SSH sessions if specified.
 - Configured new logs to be appended to the log file instead of overwriting.
 - Updated spec tests.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
   * [What simp_bolt affects](#what-simp_bolt-affects)
   * [Beginning with simp_bolt](#beginning-with-simp_bolt)
 * [Usage](#usage)
-  * [Within the SIMP Omni-Environment](#within-the-simp-omni-environment)
 * [Reference](#reference)
 * [Limitations](#limitations)
 * [Development](#development)
@@ -109,14 +108,6 @@ system as a `bolt_controller` in Hiera.
 simp_bolt::bolt_controller: true
 ```
 
-To configure a Bolt controller to utilize a SIMP Omni-Environment, which
-must be generated first, specify the name of the environment in Hiera.
-
-```yaml
-simp_bolt::simp_environment: true
-simp_bolt::simp_environment_name: bolt
-```
-
 To configure a system that will be managed by Bolt, simply `include simp_bolt`
 and specify the system as a ``bolt_target`` in Hiera.
 
@@ -130,7 +121,7 @@ remote systems. Both can be specified in Hiera.  Passwords should be in
 
 ```yaml
 simp_bolt::user::password: '$6$0BVLUF[...]16OtkdiY1'
-simp_bolt::user::ssh_authorized_key: 'AAAAB3Nza[...]qXfdaQ=='
+simp_bolt::user::ssh_authorized_keys: 'AAAAB3Nza[...]qXfdaQ=='
 ```
 
 ## Usage
@@ -158,33 +149,6 @@ simp_bolt::config::modulepath: /path/to/modules
 
 To apply an existing manifest, `su` to the bolt user and execute
 `bolt apply <manifest> --nodes <NODE NAME(S)> --password --sudo-password`.
-
-### Within the SIMP Omni-Environment
-
-The `simp_bolt` module is compatible with the SIMP Omni-Evironment to apply
-SIMP settings to target systems.  To utilize a SIMP Omni-Environment, copy the
-contents of `/usr/share/simp/environment-skeleton/puppet` to the desired Puppet
-environment directory, which will also serve as the Boltdir. Copy the contents
-of `/usr/share/simp/environment-skeleton/secondary` and 
-`/usr/share/simp/environment-skeleton/writable` to the desired destinations.
-The paths for all three of the enviroments, as well as the environment name,
-are configurable in Hiera. After copying the environment skeletons, change
-directories to the Puppet Environment directory and execute the following
-SIMP and Bolt commands to generate the Puppetfiles and install the modules.
-
-```shell
-simp puppetfile generate -s > Puppetfile
-simp puppetfile generate > Puppetfile.simp
-bolt puppetfile install
-```
-
-To apply the SIMP environment to a target system, modify the Hiera files as 
-needed and execute
-`bolt apply manifests/site.pp --nodes <NODE NAME(S)> --password --sudo-password`
-from within the Boltdir directory. If the target system does not have the
-specified target user account configured, it will be necessary to also specify
-`--user username --run-as root` where username is an existing account on the
-target system with permissions to run sudo commands.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   * [What simp_bolt affects](#what-simp_bolt-affects)
   * [Beginning with simp_bolt](#beginning-with-simp_bolt)
 * [Usage](#usage)
+  * [Within the SIMP Omni-Environment](#within-the-simp-omni-environment)
 * [Reference](#reference)
 * [Limitations](#limitations)
 * [Development](#development)
@@ -38,10 +39,10 @@ specified on both controllers and target systems to be managed with Bolt.
 
 Bolt is an open source task runner developed by Puppet that permits automation
 on an as-needed basis. This means that all actions are initiated from the Bolt
-server, eliminating reliance upon remote agent software for task execution.
+controller, eliminating reliance upon remote agent software for task execution.
 More complex tasks can be implemented using Puppet modules, which does require
 the installation of an agent for executions, but all tasks are still initiated
-from the Bolt server.
+from the Bolt controller.
 
 See [REFERENCE.md](REFERENCE.md) for more details.
 
@@ -108,6 +109,14 @@ system as a `bolt_controller` in Hiera.
 simp_bolt::bolt_controller: true
 ```
 
+To configure a Bolt controller to utilize a SIMP Omni-Environment, specify
+the name of the environment in Hiera.
+
+```yaml
+simp_bolt::simp_environment: true
+simp_bolt::simp_environment_name: bolt
+```
+
 To configure a system that will be managed by Bolt, simply `include simp_bolt`
 and specify the system as a ``bolt_target`` in Hiera.
 
@@ -128,7 +137,7 @@ simp_bolt::user::ssh_authorized_key: 'AAAAB3Nza[...]qXfdaQ=='
 
 Once the `simp_bolt` module has been applied to a server and one or more target
 systems, Bolt is ready for use. All commands provided assume you have changed
-users to the appropriate account using `su` on the Bolt server system.
+users to the appropriate account using `su` on the Bolt controller system.
 Entering the command `bolt` by itself will display the help information.
 
 To run a remote command, `su` to the bolt user and execute
@@ -149,6 +158,27 @@ simp_bolt::config::modulepath: /path/to/modules
 
 To apply an existing manifest, `su` to the bolt user and execute
 `bolt apply <manifest> --nodes <NODE NAME(S)> --password --sudo-password`.
+
+### Within the SIMP Omni-Environment
+
+If utilizing a SIMP Omni-Environment, change directories to the Puppet
+Environment directory, /etc/puppetlabs/code/environments/bolt, and execute
+Bolt commands there so the appropriate configuration files will be utilized.
+The environment can be created with the command `simpenv -n bolt` run as root.
+
+The Puppetfile and Puppetfile.simp behave the same as the traditional SIMP
+on a Puppet system. To install or update the modules as specified in the
+Puppetfile, simply execute 
+`bolt puppetfile install --boltdir /etc/puppetlabs/code/environments/bolt`.
+Specifying the boltdir is only necessary if a bolt.yaml file is not present
+or if the command is run from a different directory.
+
+To apply the SIMP environment to a target system, execute 
+`bolt apply manifests/site.pp --nodes <NODE NAME(S)> --password --sudo-password`
+from within the Puppet Environment directory. If the target system does not
+have the specified target user account configured, it will be necessary to also
+specify `--user username --run-as root` where username is an existing account
+on the target system with permissions to run sudo commands.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -161,24 +161,30 @@ To apply an existing manifest, `su` to the bolt user and execute
 
 ### Within the SIMP Omni-Environment
 
-If utilizing a SIMP Omni-Environment, change directories to the Puppet
-Environment directory, /etc/puppetlabs/code/environments/bolt, and execute
-Bolt commands there so the appropriate configuration files will be utilized.
-The environment can be created with the command `simpenv -n bolt` run as root.
+The `simp_bolt` module is compatible with the SIMP Omni-Evironment to apply
+SIMP settings to target systems.  To utilize a SIMP Omni-Environment, copy the
+contents of `/usr/share/simp/environment-skeleton/puppet` to the desire Puppet
+environment directory, which will also serve as the Boltdir. Copy the contents
+of `/usr/share/simp/environment-skeleton/secondary` and 
+`/usr/share/simp/environment-skeleton/writable` to the desired destinations.
+The paths for all three of the enviroments, as well as the environment name,
+are configurable in Hiera. After copying the environment skeletons, change
+directories to the Puppet Environment directory and execute the following
+SIMP and Bolt commands to generate the Puppetfiles and install the modules.
 
-The Puppetfile and Puppetfile.simp behave the same as the traditional SIMP
-on a Puppet system. To install or update the modules as specified in the
-Puppetfile, simply execute 
-`bolt puppetfile install --boltdir /etc/puppetlabs/code/environments/bolt`.
-Specifying the boltdir is only necessary if a bolt.yaml file is not present
-or if the command is run from a different directory.
+```shell
+simp puppetfile generate -s > Puppetfile
+simp puppetfile generate > Puppetfile.simp
+bolt puppetfile install
+```
 
-To apply the SIMP environment to a target system, execute 
+To apply the SIMP environment to a target system, modify the Hiera files as 
+needed and execute
 `bolt apply manifests/site.pp --nodes <NODE NAME(S)> --password --sudo-password`
-from within the Puppet Environment directory. If the target system does not
-have the specified target user account configured, it will be necessary to also
-specify `--user username --run-as root` where username is an existing account
-on the target system with permissions to run sudo commands.
+from within the Boltdir directory. If the target system does not have the
+specified target user account configured, it will be necessary to also specify
+`--user username --run-as root` where username is an existing account on the
+target system with permissions to run sudo commands.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ system as a `bolt_controller` in Hiera.
 simp_bolt::bolt_controller: true
 ```
 
-To configure a Bolt controller to utilize a SIMP Omni-Environment, specify
-the name of the environment in Hiera.
+To configure a Bolt controller to utilize a SIMP Omni-Environment, which
+must be generated first, specify the name of the environment in Hiera.
 
 ```yaml
 simp_bolt::simp_environment: true
@@ -163,7 +163,7 @@ To apply an existing manifest, `su` to the bolt user and execute
 
 The `simp_bolt` module is compatible with the SIMP Omni-Evironment to apply
 SIMP settings to target systems.  To utilize a SIMP Omni-Environment, copy the
-contents of `/usr/share/simp/environment-skeleton/puppet` to the desire Puppet
+contents of `/usr/share/simp/environment-skeleton/puppet` to the desired Puppet
 environment directory, which will also serve as the Boltdir. Copy the contents
 of `/usr/share/simp/environment-skeleton/secondary` and 
 `/usr/share/simp/environment-skeleton/writable` to the desired destinations.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -155,46 +155,6 @@ $home directory for the account specified in the user.pp manifest.
 
 Default value: pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt')
 
-##### `simp_omni_environment`
-
-Data type: `Boolean`
-
-Use the SIMP Omni-Environment.
-
-Default value: `false`
-
-##### `simp_environment_name`
-
-Data type: `Optional[String[1]]`
-
-The name of the SIMP Omni-Environment to use.
-
-Default value: 'bolt'
-
-##### `puppet_env_path`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-The path to the Puppet environment in the SIMP Omni-Environment.
-
-Default value: `undef`
-
-##### `secondary_env_path`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-The path to the secondary environment in the SIMP Omni-Environment.
-
-Default value: `undef`
-
-##### `writable_env_path`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-The path to the writable environment in the SIMP Omni-Environment.
-
-Default value: `undef`
-
 ##### `config_hash`
 
 Data type: `Optional[Hash]`
@@ -319,7 +279,7 @@ Data type: `Boolean`
 
 Request a pseudo TTY on nodes that support it. By default in Bolt this is false.
 
-Default value: $simp_omni_environment
+Default value: `true`
 
 ##### `transport_options`
 
@@ -331,13 +291,13 @@ without any error checking of key/value pairs.
 You must have settings specified for the ``$default_transport``
 
 Default value: {
-                                                               'ssh' => {
-                                                                 'tmpdir' => $simp_bolt::target_user_home,
-                                                                 'user'   => $simp_bolt::target_user_name,
-                                                                 'run-as' => getvar(simp_bolt::target_sudo_user),
-                                                                 'tty'    => $tty
-                                                               }.delete_undef_values
-                                                             }
+                                                              'ssh' => {
+                                                                'tmpdir' => $simp_bolt::target_user_home,
+                                                                'user'   => $simp_bolt::target_user_name,
+                                                                'run-as' => getvar(simp_bolt::target_sudo_user),
+                                                                'tty'    => $tty
+                                                              }.delete_undef_values
+                                                            }
 
 ### simp_bolt::controller::install
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,6 +12,11 @@
 * [`simp_bolt::target`](#simp_bolttarget): Configure a system to be managed by Puppet Bolt
 * [`simp_bolt::target::user`](#simp_bolttargetuser): Configure a 'simp_bolt' system user and login capabilities
 
+**Data types**
+
+* [`Simp_bolt::LogLevel`](#simp_boltloglevel): Bolt Log Levels
+* [`Simp_bolt::Transport`](#simp_bolttransport): Bolt Transports
+
 ## Classes
 
 ### simp_bolt
@@ -69,6 +74,22 @@ Configure the system as a target for Bolt management
 
 Default value: `false`
 
+##### `simp_environment`
+
+Data type: `Boolean`
+
+Utilize the SIMP Omni-Environment.
+
+Default value: `false`
+
+##### `simp_environment_name`
+
+Data type: `String`
+
+The name of the SIMP Omni-Environment.
+
+Default value: 'bolt'
+
 ##### `package_name`
 
 Data type: `String`
@@ -123,6 +144,15 @@ https://puppet.com/docs/bolt/latest/bolt_configuration_options.html.
 
 The following parameters are available in the `simp_bolt::controller::config` class.
 
+##### `local_user`
+
+Data type: `Optional[String[1]]`
+
+The local account to be used for running Bolt. The default is the $username account specified
+in the user.pp manifest.
+
+Default value: getvar(simp_bolt::controller::local_user_name)
+
 ##### `local_group`
 
 Data type: `Optional[String[1]]`
@@ -132,19 +162,30 @@ default is the $username account specified in the user.pp manifest.
 
 Default value: getvar(simp_bolt::controller::local_group_name)
 
-##### `local_user_home`
+##### `local_home`
+
+Data type: `Stdlib::Unixpath`
 
 The home directory of the local account to be used for running Bolt. The default is the
 $home directory for the account specified in the user.pp manifest.
 
-##### `local_user`
+Default value: pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt')
+
+##### `use_simp_env`
+
+Data type: `Boolean`
+
+Use the SIMP Omni-Environment.
+
+Default value: getvar(simp_bolt::simp_environment)
+
+##### `use_simp_env_name`
 
 Data type: `Optional[String[1]]`
 
-The local account to be used for running Bolt. The default is the $username account specified
-in the user.pp manifest.
+The name of the SIMP Omni-Environment to use.
 
-Default value: getvar(simp_bolt::controller::local_user_name)
+Default value: getvar(simp_bolt::simp_environment_name)
 
 ##### `config_hash`
 
@@ -251,7 +292,7 @@ Data type: `Boolean`
 
 Add output to an existing log file. By default in Bolt this is true.
 
-Default value: `false`
+Default value: `true`
 
 ##### `modulepath`
 
@@ -264,25 +305,29 @@ in `~/.puppetlabs/bolt`.
 
 Default value: `undef`
 
-##### `local_home`
+##### `tty`
 
-Data type: `Stdlib::Unixpath`
+Data type: `Boolean`
 
+Request a pseudo TTY on nodes that support it. By default in Bolt this is false.
 
-
-Default value: pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt')
+Default value: getvar(simp_bolt::simp_environment)
 
 ##### `transport_options`
 
 Data type: `Hash[Simp_bolt::Transport, Hash]`
 
+A Hash of transport options that will be added to the configuration file
+without any error checking of key/value pairs.
 
+You must have settings specified for the ``$default_transport``
 
 Default value: {
                                                             'ssh' => {
                                                               'tmpdir' => $simp_bolt::target_user_home,
                                                               'user'   => $simp_bolt::target_user_name,
-                                                              'run-as' => getvar(simp_bolt::target_sudo_user)
+                                                              'run-as' => getvar(simp_bolt::target_sudo_user),
+                                                              'tty'    => $tty
                                                             }.delete_undef_values
                                                           }
 
@@ -492,11 +537,15 @@ The GID of the user
 
 Default value: $simp_bolt::target::user_gid
 
-##### `ssh_authorized_key`
+##### `ssh_authorized_keys`
+
+Data type: `Optional[Array[String[1]]]`
 
 The SSH public key for the user
 
 * See the native ``ssh_authorized_key`` resource definition for details
+
+Default value: getvar(simp_bolt::target::user_ssh_authorized_keys)
 
 ##### `ssh_authorized_key_type`
 
@@ -508,9 +557,13 @@ The SSH public key type
 
 Default value: $simp_bolt::target::user_ssh_authorized_key_type
 
-##### `sudo_users`
+##### `sudo_user`
+
+Data type: `Optional[String[1]]`
 
 The users that the ``username`` user may escalate to
+
+Default value: getvar(simp_bolt::target::user_sudo_user)
 
 ##### `sudo_password_required`
 
@@ -549,19 +602,17 @@ The ``pam_limits`` restricting the number of concurrent sessions permitted for
 
 Default value: getvar(simp_bolt::target::user_max_logins)
 
-##### `ssh_authorized_keys`
+## Data types
 
-Data type: `Optional[Array[String[1]]]`
+### Simp_bolt::LogLevel
 
+Bolt Log Levels
 
+Alias of `Enum['debug', 'info', 'notice', 'warn', 'error']`
 
-Default value: getvar(simp_bolt::target::user_ssh_authorized_keys)
+### Simp_bolt::Transport
 
-##### `sudo_user`
+Bolt Transports
 
-Data type: `Optional[String[1]]`
-
-
-
-Default value: getvar(simp_bolt::target::user_sudo_user)
+Alias of `Enum['docker', 'local', 'pcp', 'ssh', 'winrm']`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,7 +5,7 @@
 
 **Classes**
 
-* [`simp_bolt`](#simp_bolt): Installs and configures Puppet Bolt for use within the SIMP enviroment
+* [`simp_bolt`](#simp_bolt): Installs and configures Puppet Bolt for use within the SIMP environment
 * [`simp_bolt::controller`](#simp_boltcontroller): Installs and configures Puppet Bolt for use within the SIMP enviroment
 * [`simp_bolt::controller::config`](#simp_boltcontrollerconfig): Set the global configuration and transport options for Bolt.
 * [`simp_bolt::controller::install`](#simp_boltcontrollerinstall): This class is called from simp_bolt for install.
@@ -73,22 +73,6 @@ Configure the system as a target for Bolt management
   ``simp_bolt::target`` parameters.
 
 Default value: `false`
-
-##### `simp_environment`
-
-Data type: `Boolean`
-
-Utilize the SIMP Omni-Environment.
-
-Default value: `false`
-
-##### `simp_environment_name`
-
-Data type: `String`
-
-The name of the SIMP Omni-Environment.
-
-Default value: 'bolt'
 
 ##### `package_name`
 
@@ -171,21 +155,45 @@ $home directory for the account specified in the user.pp manifest.
 
 Default value: pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt')
 
-##### `use_simp_env`
+##### `simp_omni_environment`
 
 Data type: `Boolean`
 
 Use the SIMP Omni-Environment.
 
-Default value: getvar(simp_bolt::simp_environment)
+Default value: `false`
 
-##### `use_simp_env_name`
+##### `simp_environment_name`
 
 Data type: `Optional[String[1]]`
 
 The name of the SIMP Omni-Environment to use.
 
-Default value: getvar(simp_bolt::simp_environment_name)
+Default value: 'bolt'
+
+##### `puppet_env_path`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+The path to the Puppet environment in the SIMP Omni-Environment.
+
+Default value: `undef`
+
+##### `secondary_env_path`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+The path to the secondary environment in the SIMP Omni-Environment.
+
+Default value: `undef`
+
+##### `writable_env_path`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+The path to the writable environment in the SIMP Omni-Environment.
+
+Default value: `undef`
 
 ##### `config_hash`
 
@@ -311,7 +319,7 @@ Data type: `Boolean`
 
 Request a pseudo TTY on nodes that support it. By default in Bolt this is false.
 
-Default value: getvar(simp_bolt::simp_environment)
+Default value: $simp_omni_environment
 
 ##### `transport_options`
 
@@ -323,13 +331,13 @@ without any error checking of key/value pairs.
 You must have settings specified for the ``$default_transport``
 
 Default value: {
-                                                            'ssh' => {
-                                                              'tmpdir' => $simp_bolt::target_user_home,
-                                                              'user'   => $simp_bolt::target_user_name,
-                                                              'run-as' => getvar(simp_bolt::target_sudo_user),
-                                                              'tty'    => $tty
-                                                            }.delete_undef_values
-                                                          }
+                                                               'ssh' => {
+                                                                 'tmpdir' => $simp_bolt::target_user_home,
+                                                                 'user'   => $simp_bolt::target_user_name,
+                                                                 'run-as' => getvar(simp_bolt::target_sudo_user),
+                                                                 'tty'    => $tty
+                                                               }.delete_undef_values
+                                                             }
 
 ### simp_bolt::controller::install
 

--- a/manifests/controller/config.pp
+++ b/manifests/controller/config.pp
@@ -5,17 +5,23 @@
 # Addtional details on the options can be found at
 # https://puppet.com/docs/bolt/latest/bolt_configuration_options.html.
 #
+# @param local_user
+#   The local account to be used for running Bolt. The default is the $username account specified
+#   in the user.pp manifest.
+#
 # @param local_group
 #   The local group to be used for file permissions associated with the local_user account. The
 #   default is the $username account specified in the user.pp manifest.
 #
-# @param local_user_home
+# @param local_home
 #   The home directory of the local account to be used for running Bolt. The default is the
 #   $home directory for the account specified in the user.pp manifest.
 #
-# @param local_user
-#   The local account to be used for running Bolt. The default is the $username account specified
-#   in the user.pp manifest.
+# @param use_simp_env
+#   Use the SIMP Omni-Environment.
+#
+# @param use_simp_env_name
+#   The name of the SIMP Omni-Environment to use.
 #
 # @param config_hash
 #   If specified, will be passed to the ``to_yaml`` function and output at the
@@ -70,7 +76,10 @@
 #   By default, in Bolt, this is "modules:site-modules:site" within the Bolt project directory
 #   in `~/.puppetlabs/bolt`.
 #
-# @params transport_options
+# @param tty
+#   Request a pseudo TTY on nodes that support it. By default in Bolt this is false.
+#
+# @param transport_options
 #   A Hash of transport options that will be added to the configuration file
 #   without any error checking of key/value pairs.
 #
@@ -81,6 +90,10 @@ class simp_bolt::controller::config (
   Optional[String[1]]              $local_user         = getvar(simp_bolt::controller::local_user_name),
   Optional[String[1]]              $local_group        = getvar(simp_bolt::controller::local_group_name),
   Stdlib::Unixpath                 $local_home         = pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt'),
+
+  # SIMP environment options
+  Boolean                          $use_simp_env       = getvar(simp_bolt::simp_environment),
+  Optional[String[1]]              $use_simp_env_name  = getvar(simp_bolt::simp_environment_name),
 
   # Config File Specification
   Optional[Hash]                   $config_hash        = undef,
@@ -94,17 +107,19 @@ class simp_bolt::controller::config (
   Optional[String[1]]              $hiera_config       = undef,
   Optional[String[1]]              $inventoryfile      = undef,
   Simp_bolt::LogLevel              $log_console_level  = 'info',
-  Boolean                          $log_file_append    = false,
-  Simp_bolt::LogLevel              $log_file_level     = 'info',
   Stdlib::Unixpath                 $log_file           = '/var/log/puppetlabs/bolt/bolt.log',
+  Simp_bolt::LogLevel              $log_file_level     = 'info',
+  Boolean                          $log_file_append    = true,
   Optional[String[1]]              $modulepath         = undef,
 
   # Overall Transport Options
+  Boolean                          $tty                = getvar(simp_bolt::simp_environment),
   Hash[Simp_bolt::Transport, Hash] $transport_options  = {
                                                             'ssh' => {
                                                               'tmpdir' => $simp_bolt::target_user_home,
                                                               'user'   => $simp_bolt::target_user_name,
-                                                              'run-as' => getvar(simp_bolt::target_sudo_user)
+                                                              'run-as' => getvar(simp_bolt::target_sudo_user),
+                                                              'tty'    => $tty
                                                             }.delete_undef_values
                                                           }
 ){
@@ -129,28 +144,42 @@ class simp_bolt::controller::config (
     $_create_log_dir = false
   }
 
-  $_bolt_dir = "${_puppet_dir}/bolt"
+  if $use_simp_env {
+    $_bolt_dir = "/etc/puppetlabs/code/environments/${use_simp_env_name}"
+    if $modulepath {
+      $_modulepath = $modulepath
+    }
+    else {
+      $_modulepath = "modules:site-modules:site:/var/simp/environments/${use_simp_env_name}/site_files:\$basemodulepath"
+    }
+  }
+  else {
+    $_bolt_dir = "${_puppet_dir}/bolt"
+    $_modulepath = $modulepath
 
-  exec { 'Create Local Bolt Home':
-    command => "mkdir -p ${local_home}",
-    path    => ['/bin','/usr/bin'],
-    umask   => '022',
-    unless  => "test -d ${local_home}"
+    exec { 'Create Local Bolt Home':
+      command => "mkdir -p ${local_home}",
+      path    => ['/bin','/usr/bin'],
+      umask   => '022',
+      unless  => "test -d ${local_home}"
+    }
+
+    file { $_puppet_dir:
+      ensure  => 'directory',
+      owner   => $_local_user,
+      group   => $_local_group,
+      mode    => $_bolt_dir_mode,
+      require => Exec['Create Local Bolt Home']
+    }
+
   }
 
-  file { $_puppet_dir:
+  file { $_bolt_dir:
     ensure  => 'directory',
     owner   => $_local_user,
     group   => $_local_group,
     mode    => $_bolt_dir_mode,
-    require => Exec['Create Local Bolt Home']
-  }
-
-  file { $_bolt_dir:
-    ensure => 'directory',
-    owner  => $_local_user,
-    group  => $_local_group,
-    mode   => $_bolt_dir_mode
+    recurse => true
   }
 
   # Create the config file for bolt
@@ -171,7 +200,7 @@ class simp_bolt::controller::config (
         log_file_append   => $log_file_append,
         log_file_level    => $log_file_level,
         log_file          => $log_file,
-        modulepath        => $modulepath,
+        modulepath        => $_modulepath,
         transport_options => $transport_options
       }
     )

--- a/manifests/controller/config.pp
+++ b/manifests/controller/config.pp
@@ -166,20 +166,22 @@ class simp_bolt::controller::config (
     owner   => $_local_user,
     group   => $_local_group,
     mode    => $_bolt_dir_mode,
-    content => epp("${module_name}/bolt_yaml.epp", {
-      config_hash       => $config_hash,
-      color             => $color,
-      concurrency       => $concurrency,
-      default_transport => $default_transport,
-      format            => $format,
-      hiera_config      => $hiera_config,
-      inventoryfile     => $inventoryfile,
-      log_console_level => $log_console_level,
-      log_file_append   => $log_file_append,
-      log_file_level    => $log_file_level,
-      log_file          => $log_file,
-      modulepath        => $_modulepath,
-      transport_options => $transport_options
+    content => epp(
+      "${module_name}/bolt_yaml.epp",
+      {
+        config_hash       => $config_hash,
+        color             => $color,
+        concurrency       => $concurrency,
+        default_transport => $default_transport,
+        format            => $format,
+        hiera_config      => $hiera_config,
+        inventoryfile     => $inventoryfile,
+        log_console_level => $log_console_level,
+        log_file_append   => $log_file_append,
+        log_file_level    => $log_file_level,
+        log_file          => $log_file,
+        modulepath        => $_modulepath,
+        transport_options => $transport_options
       }
     )
   }

--- a/manifests/controller/config.pp
+++ b/manifests/controller/config.pp
@@ -81,37 +81,37 @@
 #
 class simp_bolt::controller::config (
   # Local Target Directory Options
-  Optional[String[1]]              $local_user            = getvar(simp_bolt::controller::local_user_name),
-  Optional[String[1]]              $local_group           = getvar(simp_bolt::controller::local_group_name),
-  Stdlib::Unixpath                 $local_home            = pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt'),
+  Optional[String[1]]              $local_user        = getvar(simp_bolt::controller::local_user_name),
+  Optional[String[1]]              $local_group       = getvar(simp_bolt::controller::local_group_name),
+  Stdlib::Unixpath                 $local_home        = pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt'),
 
   # Config File Specification
-  Optional[Hash]                   $config_hash           = undef,
+  Optional[Hash]                   $config_hash       = undef,
 
   # Global Bolt Options
-  Boolean                          $color                 = true,
-  Optional[Integer[0]]             $concurrency           = undef,
-  Simp_bolt::Transport             $default_transport     = 'ssh',
-  Boolean                          $disable_analytics     = true,
-  Optional[Enum['human','json']]   $format                = undef,
-  Optional[String[1]]              $hiera_config          = undef,
-  Optional[String[1]]              $inventoryfile         = undef,
-  Simp_bolt::LogLevel              $log_console_level     = 'info',
-  Stdlib::Unixpath                 $log_file              = '/var/log/puppetlabs/bolt/bolt.log',
-  Simp_bolt::LogLevel              $log_file_level        = 'info',
-  Boolean                          $log_file_append       = true,
-  Optional[String[1]]              $modulepath            = undef,
+  Boolean                          $color             = true,
+  Optional[Integer[0]]             $concurrency       = undef,
+  Simp_bolt::Transport             $default_transport = 'ssh',
+  Boolean                          $disable_analytics = true,
+  Optional[Enum['human','json']]   $format            = undef,
+  Optional[String[1]]              $hiera_config      = undef,
+  Optional[String[1]]              $inventoryfile     = undef,
+  Simp_bolt::LogLevel              $log_console_level = 'info',
+  Stdlib::Unixpath                 $log_file          = '/var/log/puppetlabs/bolt/bolt.log',
+  Simp_bolt::LogLevel              $log_file_level    = 'info',
+  Boolean                          $log_file_append   = true,
+  Optional[String[1]]              $modulepath        = undef,
 
   # Overall Transport Options
-  Boolean                          $tty                   = true,
-  Hash[Simp_bolt::Transport, Hash] $transport_options     = {
-                                                              'ssh' => {
-                                                                'tmpdir' => $simp_bolt::target_user_home,
-                                                                'user'   => $simp_bolt::target_user_name,
-                                                                'run-as' => getvar(simp_bolt::target_sudo_user),
-                                                                'tty'    => $tty
-                                                              }.delete_undef_values
-                                                            }
+  Boolean                          $tty               = true,
+  Hash[Simp_bolt::Transport, Hash] $transport_options = {
+                                                          'ssh' => {
+                                                            'tmpdir' => $simp_bolt::target_user_home,
+                                                            'user'   => $simp_bolt::target_user_name,
+                                                            'run-as' => getvar(simp_bolt::target_sudo_user),
+                                                            'tty'    => $tty
+                                                          }.delete_undef_values
+                                                        }
 ){
   assert_private()
 
@@ -167,19 +167,19 @@ class simp_bolt::controller::config (
     group   => $_local_group,
     mode    => $_bolt_dir_mode,
     content => epp("${module_name}/bolt_yaml.epp", {
-        config_hash       => $config_hash,
-        color             => $color,
-        concurrency       => $concurrency,
-        default_transport => $default_transport,
-        format            => $format,
-        hiera_config      => $hiera_config,
-        inventoryfile     => $inventoryfile,
-        log_console_level => $log_console_level,
-        log_file_append   => $log_file_append,
-        log_file_level    => $log_file_level,
-        log_file          => $log_file,
-        modulepath        => $_modulepath,
-        transport_options => $transport_options
+      config_hash       => $config_hash,
+      color             => $color,
+      concurrency       => $concurrency,
+      default_transport => $default_transport,
+      format            => $format,
+      hiera_config      => $hiera_config,
+      inventoryfile     => $inventoryfile,
+      log_console_level => $log_console_level,
+      log_file_append   => $log_file_append,
+      log_file_level    => $log_file_level,
+      log_file          => $log_file,
+      modulepath        => $_modulepath,
+      transport_options => $transport_options
       }
     )
   }

--- a/manifests/controller/config.pp
+++ b/manifests/controller/config.pp
@@ -17,21 +17,6 @@
 #   The home directory of the local account to be used for running Bolt. The default is the
 #   $home directory for the account specified in the user.pp manifest.
 #
-# @param simp_omni_environment
-#   Use the SIMP Omni-Environment.
-#
-# @param simp_environment_name
-#   The name of the SIMP Omni-Environment to use.
-#
-# @param puppet_env_path
-#   The path to the Puppet environment in the SIMP Omni-Environment.
-#
-# @param secondary_env_path
-#   The path to the secondary environment in the SIMP Omni-Environment.
-#
-# @param writable_env_path
-#   The path to the writable environment in the SIMP Omni-Environment.
-#
 # @param config_hash
 #   If specified, will be passed to the ``to_yaml`` function and output at the
 #   entire configuation of the ``bolt.yaml`` configuation file.
@@ -100,13 +85,6 @@ class simp_bolt::controller::config (
   Optional[String[1]]              $local_group           = getvar(simp_bolt::controller::local_group_name),
   Stdlib::Unixpath                 $local_home            = pick(getvar(simp_bolt::controller::local_user_home), '/var/local/simp_bolt'),
 
-  # SIMP environment options
-  Boolean                          $simp_omni_environment = false,
-  Optional[String[1]]              $simp_environment_name = 'bolt',
-  Optional[Stdlib::Unixpath]       $puppet_env_path       = undef,
-  Optional[Stdlib::Unixpath]       $secondary_env_path    = undef,
-  Optional[Stdlib::Unixpath]       $writable_env_path     = undef,
-
   # Config File Specification
   Optional[Hash]                   $config_hash           = undef,
 
@@ -125,7 +103,7 @@ class simp_bolt::controller::config (
   Optional[String[1]]              $modulepath            = undef,
 
   # Overall Transport Options
-  Boolean                          $tty                   = $simp_omni_environment,
+  Boolean                          $tty                   = true,
   Hash[Simp_bolt::Transport, Hash] $transport_options     = {
                                                               'ssh' => {
                                                                 'tmpdir' => $simp_bolt::target_user_home,
@@ -156,39 +134,8 @@ class simp_bolt::controller::config (
     $_create_log_dir = false
   }
 
-  if $simp_omni_environment {
-    if $puppet_env_path {
-      $_bolt_dir = "${puppet_env_path}/${simp_environment_name}"
-    }
-    else {
-      $_bolt_dir = "${_puppet_dir}/${simp_environment_name}"
-    }
-
-    if $secondary_env_path {
-      $secondary_env = "${secondary_env_path}/${simp_environment_name}"
-    }
-    else {
-      $secondary_env = "${local_home}/secondary/${simp_environment_name}"
-    }
-
-    if $writable_env_path {
-      $writable_env = "${writable_env_path}/${simp_environment_name}"
-    }
-    else {
-      $writable_env = "${local_home}/writable/${simp_environment_name}"
-    }
-
-    if $modulepath {
-      $_modulepath = $modulepath
-    }
-    else {
-      $_modulepath = "modules:site-modules:site:${secondary_env}/site_files:\$basemodulepath"
-    }
-  }
-  else {
-    $_bolt_dir = "${_puppet_dir}/bolt"
-    $_modulepath = $modulepath
-  }
+  $_bolt_dir = "${_puppet_dir}/bolt"
+  $_modulepath = $modulepath
 
   exec { 'Create Local Bolt Home':
     command => "mkdir -p ${local_home}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,12 +30,12 @@
 # @author SIMP Team <https://simp-project.com/>
 #
 class simp_bolt (
-  String[1]           $target_user_name      = 'simp_bolt',
-  Stdlib::Unixpath    $target_user_home      = "/var/local/${target_user_name}",
-  Optional[String[1]] $target_sudo_user      = 'root',
-  Boolean             $bolt_controller       = false,
-  Boolean             $bolt_target           = false,
-  String              $package_name          = 'puppet-bolt'
+  String[1]           $target_user_name = 'simp_bolt',
+  Stdlib::Unixpath    $target_user_home = "/var/local/${target_user_name}",
+  Optional[String[1]] $target_sudo_user = 'root',
+  Boolean             $bolt_controller  = false,
+  Boolean             $bolt_target      = false,
+  String              $package_name     = 'puppet-bolt'
 ) {
 
   simplib::assert_metadata($module_name)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,18 +24,26 @@
 #   * Configuration specifics should be managed via the
 #     ``simp_bolt::target`` parameters.
 #
+# @param simp_environment
+#   Utilize the SIMP Omni-Environment.
+#
+# @param simp_environment_name
+#   The name of the SIMP Omni-Environment.
+#
 # @param package_name
 #   The name of the Puppet Bolt rpm package
 #
 # @author SIMP Team <https://simp-project.com/>
 #
 class simp_bolt (
-  String[1]           $target_user_name = 'simp_bolt',
-  Stdlib::Unixpath    $target_user_home = "/var/local/${target_user_name}",
-  Optional[String[1]] $target_sudo_user = 'root',
-  Boolean             $bolt_controller  = false,
-  Boolean             $bolt_target      = false,
-  String              $package_name     = 'puppet-bolt'
+  String[1]           $target_user_name      = 'simp_bolt',
+  Stdlib::Unixpath    $target_user_home      = "/var/local/${target_user_name}",
+  Optional[String[1]] $target_sudo_user      = 'root',
+  Boolean             $bolt_controller       = false,
+  Boolean             $bolt_target           = false,
+  Boolean             $simp_environment      = false,
+  String              $simp_environment_name = 'bolt',
+  String              $package_name          = 'puppet-bolt'
 ) {
 
   simplib::assert_metadata($module_name)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# @summary Installs and configures Puppet Bolt for use within the SIMP enviroment
+# @summary Installs and configures Puppet Bolt for use within the SIMP environment
 #
 # This class will not do anything on the target system by default. You must
 # opt-in to adding either the controller or the target configuration.
@@ -24,12 +24,6 @@
 #   * Configuration specifics should be managed via the
 #     ``simp_bolt::target`` parameters.
 #
-# @param simp_environment
-#   Utilize the SIMP Omni-Environment.
-#
-# @param simp_environment_name
-#   The name of the SIMP Omni-Environment.
-#
 # @param package_name
 #   The name of the Puppet Bolt rpm package
 #
@@ -41,8 +35,6 @@ class simp_bolt (
   Optional[String[1]] $target_sudo_user      = 'root',
   Boolean             $bolt_controller       = false,
   Boolean             $bolt_target           = false,
-  Boolean             $simp_environment      = false,
-  String              $simp_environment_name = 'bolt',
   String              $package_name          = 'puppet-bolt'
 ) {
 

--- a/manifests/target/user.pp
+++ b/manifests/target/user.pp
@@ -20,7 +20,7 @@
 # @param gid
 #   The GID of the user
 #
-# @param ssh_authorized_key
+# @param ssh_authorized_keys
 #   The SSH public key for the user
 #
 #   * See the native ``ssh_authorized_key`` resource definition for details
@@ -30,7 +30,7 @@
 #
 #   * See the native ``ssh_authorized_key`` resource definition for details
 #
-# @param sudo_users
+# @param sudo_user
 #   The users that the ``username`` user may escalate to
 #
 # @param sudo_password_required

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_bolt",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "SIMP Team",
   "summary": "A SIMP module to manage Puppetlabs Bolt",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.14.1 < 4.0.0"
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -64,6 +64,24 @@ describe 'simp_bolt::controller::config' do
           it { is_expected.to create_file('/var/log/puppetlabs/bolt') }
         end
 
+        context 'with a simp environment specified' do
+          let(:params) {{
+            :use_simp_env      => true,
+            :use_simp_env_name => 'bolt'
+          }}
+          it_behaves_like "a structured module"
+          it { is_expected.not_to contain_exec('Create Local Bolt Home') }
+          it { is_expected.not_to create_file('/var/local/simp_bolt/puppetlabs') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/bolt.yaml') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/data') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/hiera.yaml') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/analytics.yaml') }
+          it { is_expected.to create_file_line('analytics_yaml') }
+          it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
+          it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
+        end
+
         context 'with a config hash' do
           let(:header){
             <<-EOM

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -64,50 +64,6 @@ describe 'simp_bolt::controller::config' do
           it { is_expected.to create_file('/var/log/puppetlabs/bolt') }
         end
 
-        context 'with a simp omni-environment specified' do
-          let(:modulepath) {
-            '^modulepath: modules:site\-modules:site:\/var\/local\/simp_bolt\/secondary\/bolt\/site_files:\$basemodulepath$'
-          }
-          let(:params) {{
-            :simp_omni_environment => true
-          }}
-          it_behaves_like "a structured module"
-          it { is_expected.to contain_exec('Create Local Bolt Home').with_command('mkdir -p /var/local/simp_bolt') }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt') }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{#{modulepath}}) }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{tty: true}) }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/data') }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/hiera.yaml') }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/analytics.yaml') }
-          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
-          it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
-          it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
-        end
-
-        context 'with a simp omni-environment and environment paths specified' do
-          let(:modulepath) {
-            '^modulepath: modules:site\-modules:site:\/var\/simp\/environments\/production\/site_files:\$basemodulepath$'
-          }
-          let(:params) {{
-            :simp_omni_environment => true,
-            :simp_environment_name => 'production',
-            :puppet_env_path       => '/etc/puppetlabs/code/environments',
-            :secondary_env_path    => '/var/simp/environments',
-            :writable_env_path     => '/opt/puppetlabs/puppet/cache/simp/environments'
-          }}
-          it_behaves_like "a structured module"
-          it { is_expected.to contain_exec('Create Local Bolt Home').with_command('mkdir -p /var/local/simp_bolt') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/bolt.yaml').with_content(%r{#{modulepath}}) }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/bolt.yaml').with_content(%r{tty: true}) }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/data') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/hiera.yaml') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/analytics.yaml') }
-          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
-          it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
-          it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
-        end
-
         context 'with a config hash' do
           let(:header){
             <<-EOM

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -65,17 +65,44 @@ describe 'simp_bolt::controller::config' do
         end
 
         context 'with a simp omni-environment specified' do
+          let(:modulepath) {
+            '^modulepath: modules:site\-modules:site:\/var\/local\/simp_bolt\/secondary\/bolt\/site_files:\$basemodulepath$'
+          }
           let(:params) {{
-            :simp_omni_environment => true,
-            :simp_environment_name => 'bolt'
+            :simp_omni_environment => true
           }}
           it_behaves_like "a structured module"
           it { is_expected.to contain_exec('Create Local Bolt Home').with_command('mkdir -p /var/local/simp_bolt') }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt') }
-          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{^modulepath: modules:site\-modules:site:\/var\/local\/simp_bolt\/secondary\/bolt\/site_files:\$basemodulepath$}) }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{#{modulepath}}) }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{tty: true}) }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/data') }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/hiera.yaml') }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/analytics.yaml') }
+          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
+          it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
+          it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
+        end
+
+        context 'with a simp omni-environment and environment paths specified' do
+          let(:modulepath) {
+            '^modulepath: modules:site\-modules:site:\/var\/simp\/environments\/production\/site_files:\$basemodulepath$'
+          }
+          let(:params) {{
+            :simp_omni_environment => true,
+            :simp_environment_name => 'production',
+            :puppet_env_path       => '/etc/puppetlabs/code/environments',
+            :secondary_env_path    => '/var/simp/environments',
+            :writable_env_path     => '/opt/puppetlabs/puppet/cache/simp/environments'
+          }}
+          it_behaves_like "a structured module"
+          it { is_expected.to contain_exec('Create Local Bolt Home').with_command('mkdir -p /var/local/simp_bolt') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/bolt.yaml').with_content(%r{#{modulepath}}) }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/bolt.yaml').with_content(%r{tty: true}) }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/data') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/hiera.yaml') }
+          it { is_expected.to create_file('/etc/puppetlabs/code/environments/production/analytics.yaml') }
           it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
           it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
           it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -40,7 +40,7 @@ describe 'simp_bolt::controller::config' do
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/data') }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/hiera.yaml') }
           it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/analytics.yaml') }
-          it { is_expected.to create_file_line('analytics_yaml') }
+          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
           it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
           it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
         end
@@ -59,25 +59,24 @@ describe 'simp_bolt::controller::config' do
           it { is_expected.to create_file('/home/user/.puppetlabs/bolt/data') }
           it { is_expected.to create_file('/home/user/.puppetlabs/bolt/hiera.yaml') }
           it { is_expected.to create_file('/home/user/.puppetlabs/bolt/analytics.yaml') }
-          it { is_expected.to create_file_line('analytics_yaml') }
+          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
           it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
           it { is_expected.to create_file('/var/log/puppetlabs/bolt') }
         end
 
-        context 'with a simp environment specified' do
+        context 'with a simp omni-environment specified' do
           let(:params) {{
-            :use_simp_env      => true,
-            :use_simp_env_name => 'bolt'
+            :simp_omni_environment => true,
+            :simp_environment_name => 'bolt'
           }}
           it_behaves_like "a structured module"
-          it { is_expected.not_to contain_exec('Create Local Bolt Home') }
-          it { is_expected.not_to create_file('/var/local/simp_bolt/puppetlabs') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/bolt.yaml') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/data') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/hiera.yaml') }
-          it { is_expected.to create_file('/etc/puppetlabs/code/environments/bolt/analytics.yaml') }
-          it { is_expected.to create_file_line('analytics_yaml') }
+          it { is_expected.to contain_exec('Create Local Bolt Home').with_command('mkdir -p /var/local/simp_bolt') }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt') }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/bolt.yaml').with_content(%r{^modulepath: modules:site\-modules:site:\/var\/local\/simp_bolt\/secondary\/bolt\/site_files:\$basemodulepath$}) }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/data') }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/hiera.yaml') }
+          it { is_expected.to create_file('/var/local/simp_bolt/puppetlabs/bolt/analytics.yaml') }
+          it { is_expected.to create_file_line('analytics_yaml').with_line('disabled: true') }
           it { is_expected.to contain_exec('Create Bolt Log Dir').with_command('mkdir -p /var/log/puppetlabs/bolt') }
           it { is_expected.not_to create_file('/var/log/puppetlabs/bolt') }
         end

--- a/templates/bolt_yaml.epp
+++ b/templates/bolt_yaml.epp
@@ -23,7 +23,7 @@
 <% } else { -%>
 ---
 <%   if $modulepath { -%>
-module: <%= $modulepath %>
+modulepath: <%= $modulepath %>
 <%   } -%>
 <%   if $color { -%>
 color: <%= $color %>


### PR DESCRIPTION
Configured Bolt to utilize a SIMP Omni-Environment.
Configured Bolt to request a pseudo TTY for SSH sessions if specified.
Configured new logs to be appended to the log file instead of overwriting.
Updated spec tests.
Updated README.md and REFERENCE.md.

SIMP-7108 #close
SIMP-7107 #close