### PR TITLE
(SIMP-7848) Add PE2019.8 to pupmod-simp-simp_bolt GL pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,14 +3,14 @@
 # ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2019.5/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# SIMP 6.4      5.5      2.4.5  TBD
-# PE 2018.1     5.5      2.4.5  2020-11 (LTS)
-# PE 2019.5     6.14     2.5.7  Quarterly
+# Release       Puppet   Ruby    EOL
+# SIMP 6.4      5.5      2.4.10  TBD
+# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
+# PE 2019.8     6.16     2.5.7   2021-11 (LTS)
 ---
 stages:
   - 'sanity'
@@ -80,6 +80,13 @@ variables:
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+.pup_6_16_0: &pup_6_16_0
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '6.16.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -157,6 +164,10 @@ pup6-unit:
   <<: *pup_6
   <<: *unit_tests
 
+pup6.16.0-unit:
+  <<: *pup_6_16_0
+  <<: *unit_tests
+
 # Repo-specific content
 # ==============================================================================
 
@@ -205,3 +216,28 @@ bolt:
   script:
     - 'bundle exec rake beaker:suites[simp_env,default]'
 
+
+pup6.16.0:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'
+
+pup6.16.0-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+
+pup6.16.0-oel-combined-x64:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,oel]'
+
+pup6.16.0-oel-combined-x64-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^poxvup-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
         - 'gem install -v "~> 5.5.0" puppet'
         - 'git clean -f -x -d'
         - 'puppet module build'

--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,48 @@
-gem_sources   = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+
+ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 5.5')
+  gem 'puppet', puppet_version
   gem 'rspec'
   gem 'rspec-puppet'
-  gem 'puppet-strings'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 2.4.0', '< 3.0.0'] )
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.9', '< 6.0'])
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
 end
 
 group :development do
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.17.0', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
+end
 
+# Evaluate extra gemfiles if they exist
+extra_gemfiles = [
+  ENV['EXTRA_GEMFILE'] || '',
+  "#{__FILE__}.project",
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
 end


### PR DESCRIPTION
This patch updates the puppet and ruby versions in the Gitlab CI
pipeline to reflect the latest PE LTS releases.  Most notably, it adds
specific tests for PE2019.8 LTS.

SIMP-7922 #close
[SIMP-7848] #comment Add PE2019.8 to GL CI in pupmod-simp-simp_bolt
[SIMP-7855] #comment Update GL CI to PE2018.1.15 in pupmod-simp-simp_bolt

[SIMP-7848]: https://simp-project.atlassian.net/browse/SIMP-7848
[SIMP-7855]: https://simp-project.atlassian.net/browse/SIMP-7855